### PR TITLE
add MCP server badge

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server for running code in a secure sandbox by [E2B](https://e2b.dev).
 
+<a href="https://glama.ai/mcp/servers/o9swvhmy2i"><img width="380" height="200" src="https://glama.ai/mcp/servers/o9swvhmy2i/badge" alt="e2b-mcp-server MCP server" /></a>
+
 ## Development
 
 Install dependencies:


### PR DESCRIPTION
This PR adds a badge for the [e2b-mcp-server](https://glama.ai/mcp/servers/o9swvhmy2i) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/o9swvhmy2i"><img width="380" height="200" src="https://glama.ai/mcp/servers/o9swvhmy2i/badge" alt="e2b-mcp-server MCP server" /></a>

> [!NOTE]
> This badge is specific to Python version of e2b MCP server.

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.