### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Dockerfile for E2B MCP Server JavaScript Edition
+
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Copy package.json and package-lock.json to install dependencies
+COPY packages/js/package.json packages/js/package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application files
+COPY packages/js/ .
+
+# Build the application
+RUN npm run build
+
+FROM node:22-alpine AS release
+
+WORKDIR /app
+
+# Copy built files from builder
+COPY --from=builder /app/dist /app/dist
+
+# Install production dependencies
+RUN npm ci --omit=dev
+
+ENV NODE_ENV=production
+
+# Define the environment variable for the API key
+ENV E2B_API_KEY=
+
+ENTRYPOINT ["npx", "-y", "e2b-mcp-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,31 +4,15 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# Copy package.json and package-lock.json to install dependencies
-COPY packages/js/package.json packages/js/package-lock.json ./
+# Copy the application files
+COPY packages/js/ .
 
 # Install dependencies
 RUN npm install
 
-# Copy the rest of the application files
-COPY packages/js/ .
-
 # Build the application
 RUN npm run build
 
-FROM node:22-alpine AS release
-
-WORKDIR /app
-
-# Copy built files from builder
-COPY --from=builder /app/dist /app/dist
-
-# Install production dependencies
-RUN npm ci --omit=dev
-
 ENV NODE_ENV=production
 
-# Define the environment variable for the API key
-ENV E2B_API_KEY=
-
-ENTRYPOINT ["node", "./dist/index.js"]
+ENTRYPOINT ["node", "./build/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ ENV NODE_ENV=production
 # Define the environment variable for the API key
 ENV E2B_API_KEY=
 
-ENTRYPOINT ["npx", "-y", "e2b-mcp-server"]
+ENTRYPOINT ["node", "./dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # E2B MCP Server
-[![smithery badge](https://smithery.ai/badge/e2b)](https://smithery.ai/protocol/e2b)
+[![smithery badge](https://smithery.ai/badge/e2b)](https://smithery.ai/server/e2b)
 
 This repository contains the source code for the [E2B](https://e2b.dev) MCP server.
 
@@ -15,7 +15,7 @@ Available in two editions:
 
 ### Installing via Smithery
 
-You can also install E2B for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/e2b):
+You can also install E2B for Claude Desktop automatically via [Smithery](https://smithery.ai/server/e2b):
 
 ```bash
 npx @smithery/cli install e2b --client claude

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -16,4 +16,4 @@ startCommand:
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({ command: 'npx', args: ['-y', 'e2b-mcp-server'], env: { E2B_API_KEY: config.e2bApiKey } })
+    (config) => ({ command: 'node', args: ['./dist/index.js'], env: { E2B_API_KEY: config.e2bApiKey } })

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,19 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+build:
+  dockerBuildPath: .
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - e2bApiKey
+    properties:
+      e2bApiKey:
+        type: string
+        description: The API key for the E2B server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'npx', args: ['-y', 'e2b-mcp-server'], env: { E2B_API_KEY: config.e2bApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/e2b) and claiming it.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂