### PR TITLE
Update node version

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -50,6 +50,11 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Configure pnpm
+        run: |
+          pnpm config set auto-install-peers true
+          pnpm config set exclude-links-from-lockfile true
+
       - name: Update npm
         run: |
           npm install -g npm@^11.6


### PR DESCRIPTION
At least NPM version 11.5.1 is needed
https://docs.npmjs.com/trusted-publishers


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the publish workflow to use Node.js 22, switches to actions/setup-node@v6, and adds a step to install npm 11.6+.
> 
> - **CI/CD**:
>   - **Workflow** `/.github/workflows/publish_packages.yml`:
>     - Upgrade Node.js from `20.x` to `22.x` and use `actions/setup-node@v6`.
>     - Add step to install and verify `npm@^11.6` globally.
>     - Retain existing `pnpm` setup and configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66ae8e1f08027fd1badd6ffee79ee66180553b3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->