### PR TITLE
Fix issue with npm token

### DIFF
--- a/.github/workflows/publish_packages.yml
+++ b/.github/workflows/publish_packages.yml
@@ -71,6 +71,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
 
       - name: Update lock file
         run: pnpm i --no-link --no-frozen-lockfile


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an empty `NPM_TOKEN` env var to the Changesets release step in `.github/workflows/publish_packages.yml`.
> 
> - **CI/CD**:
>   - **GitHub Actions**: Set `NPM_TOKEN: ""` in the `Release new versions` step of `.github/workflows/publish_packages.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39b4726487f861f09b2c652e495b64dcff52360b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->